### PR TITLE
동기화 문제 해결 : 웹소켓 메시지 기반 라운드 전환 로직 개선

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,11 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
+      "/broad-room-ready": {
+        target: "http://localhost:8080",
+        changeOrigin: true,
+        secure: false,
+      },
     },
   },
 });


### PR DESCRIPTION
5초가 되면 다음 라운드로 넘어가는 기능 구현하고 싶었음

-> 동기화 문제를 방지하기 위해 서버에서 브로드캐스트된 메시지를 기준으로 클라이언트에서 계산해서 다음 라운드로 넘어가고자 함 (board-answer의 브로드캐스트 메시지를 기준으로 3초 잡음)

-> 플레이어1은 바로 시작하는데, 플레이어2의 화면이 1이 2라운드로 진입할때 1라운드 시작함(플레이어2가 한라운드씩 진행이 늦음)

-> 서버에서 브로드캐스트된 메시지가 플레이어1과 2에 동일하게 전달되지 않음

-> 플레이어2가 웹소켓이 연결되기 전 API 호출이 이루어져 메시지를 수신함

-> 그럼 플레이어1이 3초 기다렸다가 API를 호출하자!

-> 해결 